### PR TITLE
Leading slash bug

### DIFF
--- a/lib/Mojolicious/Plugin/DigestAuth/RequestHandler.pm
+++ b/lib/Mojolicious/Plugin/DigestAuth/RequestHandler.pm
@@ -176,6 +176,7 @@ sub _valid_header
 sub _fix_uri
 {
     my ($self, $uri) = @_;
+    $uri =~ s!^/!!;
     my $params = $self->_request->query_params->to_string;
 
     if($uri && $self->_request->method eq 'GET' && $params && index($uri, '?') == -1) {


### PR DESCRIPTION
$self->_request->url returns url without leading slash, but browser send in "Authorization:" header url WITH leading slash.
So here's fix. Provided by https://github.com/gibbon4ik
