### PR TITLE
Update to make tests work with Mojolicious 4.0

### DIFF
--- a/t/TestHelper.pm
+++ b/t/TestHelper.pm
@@ -23,7 +23,7 @@ sub create_action
         my $self = shift;
         $self->app->plugin('digest_auth', $options);
         $self->req->env($env);
-        $self->render_text("You're in!") if $self->digest_auth;
+        $self->render(text => "You're in!") if $self->digest_auth;
     };
 }
 


### PR DESCRIPTION
The method render_text in M::Controller is removed
from 4.0, and is replaced with render(text => ...)
