### PR TITLE
Dereference before getting the first element

### DIFF
--- a/lib/Mojolicious/Plugin/DigestAuth.pm
+++ b/lib/Mojolicious/Plugin/DigestAuth.pm
@@ -18,7 +18,7 @@ sub register
 
     my %defaults = %$user_defaults;
     $defaults{realm}   ||= 'WWW';
-    $defaults{secret}  ||= $app->can('secret') ? $app->secret : ($app->secrets||[])[0]; # >= 4.91 has no secret()
+    $defaults{secret}  ||= $app->can('secret') ? $app->secret : ($app->secrets||[])->[0]; # >= 4.91 has no secret()
     $defaults{expires} ||= 300;
 
     $app->helper(digest_auth => sub {


### PR DESCRIPTION
I was having problems with Firefox and this plugin after restarting the webserver hosting Mojolicious.

After some investigating, I found that after the webserver has been restarted a different `opaque` value is generated. This shouldn't happen, because the browsers cache the `opaque` value too (with the other `Authentication` parameters), and when they send the old one the plugin will return a `Bad request`.

With https://github.com/sshaw/Mojolicious-Plugin-DigestAuth/commit/87fc55d6f2582782838ef9b36ef5194d6a81b1af the support to the `secrets` method has been added. However, probably you have forgotten the dereferencing operator, because the method returns an array reference (and you try with `[]` too!). This fixes it, and consequently it fixes the `opaque` problems with the browsers.

Thank you for your great plugin, by the way.
