### PR TITLE
fixed small method name change on mojo route for route.t

### DIFF
--- a/t/route.t
+++ b/t/route.t
@@ -15,7 +15,7 @@ sub startup
     $self->plugin('digest_auth');
     
     my $r = $self->digest_auth('/admin', allow => TestHelper::users());	
-    $r->route('/:id')->to('controller#show');	
+    $r->_route('/:id')->to('controller#show');	
 }
 
 package App::Controller;


### PR DESCRIPTION
This should fix the small test glitch for newer versions of Mojolicious. Tested on 9.08